### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/521/421166521.geojson
+++ b/data/421/166/521/421166521.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008693,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8334d8765260e0aa151e5dc330823699",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":421166521,
-    "wof:lastmodified":1566609367,
+    "wof:lastmodified":1582318192,
     "wof:name":"Lakshmipur",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/169/477/421169477.geojson
+++ b/data/421/169/477/421169477.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008811,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afa4d83dffd4fc1b2894b73dd450bc42",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421169477,
-    "wof:lastmodified":1566609373,
+    "wof:lastmodified":1582318193,
     "wof:name":"Bandarban",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/169/707/421169707.geojson
+++ b/data/421/169/707/421169707.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008821,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf9f3900a6ba33e82615a20f1e6fb75d",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421169707,
-    "wof:lastmodified":1566609371,
+    "wof:lastmodified":1582318192,
     "wof:name":"Narsingdi",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/169/845/421169845.geojson
+++ b/data/421/169/845/421169845.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008826,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ccdb904547aad3f93a55759888cb7a32",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421169845,
-    "wof:lastmodified":1566609372,
+    "wof:lastmodified":1582318192,
     "wof:name":"Patuakhali",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/170/483/421170483.geojson
+++ b/data/421/170/483/421170483.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008855,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c70b9a5deeb087c8232ef57d3bc89295",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421170483,
-    "wof:lastmodified":1566609395,
+    "wof:lastmodified":1582318196,
     "wof:name":"Kishoreganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/172/031/421172031.geojson
+++ b/data/421/172/031/421172031.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008916,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b982e318453991159d485fa3c669693b",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421172031,
-    "wof:lastmodified":1566609383,
+    "wof:lastmodified":1582318195,
     "wof:name":"Pirojpur",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/172/439/421172439.geojson
+++ b/data/421/172/439/421172439.geojson
@@ -217,6 +217,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459008942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f4d0c2400dc6a6b0f3f7cbd57cb29a",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         }
     ],
     "wof:id":421172439,
-    "wof:lastmodified":1566609383,
+    "wof:lastmodified":1582318194,
     "wof:name":"Rajshahi",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/176/039/421176039.geojson
+++ b/data/421/176/039/421176039.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009088,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27fab80977a43ef41640757e7537942b",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":421176039,
-    "wof:lastmodified":1566609398,
+    "wof:lastmodified":1582318197,
     "wof:name":"Jessore",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/176/043/421176043.geojson
+++ b/data/421/176/043/421176043.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009088,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39bd8dbc0bd30a6e013e23abf33d6632",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":421176043,
-    "wof:lastmodified":1566609399,
+    "wof:lastmodified":1582318197,
     "wof:name":"Barguna",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/176/045/421176045.geojson
+++ b/data/421/176/045/421176045.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009088,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"807a6522ad32fe4ee13007f8f68545d2",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":421176045,
-    "wof:lastmodified":1566609399,
+    "wof:lastmodified":1582318197,
     "wof:name":"Habiganj",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/177/051/421177051.geojson
+++ b/data/421/177/051/421177051.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009131,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45f97f5395111dc3984284c01c4e7f80",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421177051,
-    "wof:lastmodified":1566609395,
+    "wof:lastmodified":1582318197,
     "wof:name":"Noakhali",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/181/477/421181477.geojson
+++ b/data/421/181/477/421181477.geojson
@@ -729,6 +729,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009297,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92786b8a196ad94bc44c4d5b823728d1",
     "wof:hierarchy":[
         {
@@ -740,7 +743,7 @@
         }
     ],
     "wof:id":421181477,
-    "wof:lastmodified":1566609384,
+    "wof:lastmodified":1582318195,
     "wof:name":"Dhaka",
     "wof:parent_id":421187803,
     "wof:placetype":"locality",

--- a/data/421/181/771/421181771.geojson
+++ b/data/421/181/771/421181771.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009306,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52d945c551bcd07536e045bfc14648f8",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":421181771,
-    "wof:lastmodified":1566609385,
+    "wof:lastmodified":1582318195,
     "wof:name":"Feni",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/182/115/421182115.geojson
+++ b/data/421/182/115/421182115.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009319,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a93dd67afc7e2c4f42d1c5cabc9d5749",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421182115,
-    "wof:lastmodified":1566609397,
+    "wof:lastmodified":1582318197,
     "wof:name":"Natore",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/183/929/421183929.geojson
+++ b/data/421/183/929/421183929.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6437b9d5f6b430cfe89c2fc69d8b1ae9",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421183929,
-    "wof:lastmodified":1566609397,
+    "wof:lastmodified":1582318197,
     "wof:name":"Madaripur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/184/491/421184491.geojson
+++ b/data/421/184/491/421184491.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009412,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f537c63ee652ac90cd29db5e9e72af37",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":421184491,
-    "wof:lastmodified":1566609394,
+    "wof:lastmodified":1582318196,
     "wof:name":"Bhola",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/185/469/421185469.geojson
+++ b/data/421/185/469/421185469.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c5ab1139633460af7b940907a824afd",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421185469,
-    "wof:lastmodified":1566609400,
+    "wof:lastmodified":1582318198,
     "wof:name":"Mymensingh",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/185/471/421185471.geojson
+++ b/data/421/185/471/421185471.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c46c92c23b58209599ede99f2cf5ac31",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421185471,
-    "wof:lastmodified":1566609400,
+    "wof:lastmodified":1582318197,
     "wof:name":"Tangail",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/185/473/421185473.geojson
+++ b/data/421/185/473/421185473.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2675217bf59d46e947acc63513655608",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421185473,
-    "wof:lastmodified":1566609400,
+    "wof:lastmodified":1582318197,
     "wof:name":"Khulna",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/187/745/421187745.geojson
+++ b/data/421/187/745/421187745.geojson
@@ -226,6 +226,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009522,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57addd09a0a2aae181e9c9d813e74a45",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421187745,
-    "wof:lastmodified":1566609379,
+    "wof:lastmodified":1582318194,
     "wof:name":"Barisal",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/187/747/421187747.geojson
+++ b/data/421/187/747/421187747.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009523,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"912fdc8f6a4f29cc572dc64b242fe4b9",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421187747,
-    "wof:lastmodified":1566609377,
+    "wof:lastmodified":1582318193,
     "wof:name":"Bagerhat",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/187/793/421187793.geojson
+++ b/data/421/187/793/421187793.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009524,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8f806fd87f2b488057fba18d4da48cc",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421187793,
-    "wof:lastmodified":1566609378,
+    "wof:lastmodified":1582318193,
     "wof:name":"Bogra",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/187/795/421187795.geojson
+++ b/data/421/187/795/421187795.geojson
@@ -219,6 +219,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009524,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8269cea027eea0731f92714dc1a95390",
     "wof:hierarchy":[
         {
@@ -229,7 +232,7 @@
         }
     ],
     "wof:id":421187795,
-    "wof:lastmodified":1566609378,
+    "wof:lastmodified":1582318194,
     "wof:name":"Sylhet",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/187/801/421187801.geojson
+++ b/data/421/187/801/421187801.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009524,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"025f4412fb24cfd955933c51dd99f5c1",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":421187801,
-    "wof:lastmodified":1566609379,
+    "wof:lastmodified":1582318194,
     "wof:name":"Comilla",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/187/803/421187803.geojson
+++ b/data/421/187/803/421187803.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009524,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b387536841bbd34dfe7ee1e542167dac",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":421187803,
-    "wof:lastmodified":1566609377,
+    "wof:lastmodified":1582318193,
     "wof:name":"Dhaka",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/188/359/421188359.geojson
+++ b/data/421/188/359/421188359.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009543,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8afaa7deaeaffc867b3645631576a0a1",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421188359,
-    "wof:lastmodified":1566609382,
+    "wof:lastmodified":1582318194,
     "wof:name":"Shariatpur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/188/983/421188983.geojson
+++ b/data/421/188/983/421188983.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009595,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95a5cf81849c699e0c43b9d0002c9dc0",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":421188983,
-    "wof:lastmodified":1566609381,
+    "wof:lastmodified":1582318194,
     "wof:name":"Rangamati",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/190/979/421190979.geojson
+++ b/data/421/190/979/421190979.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009675,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"974a023e6275eef42497858a8ef824f3",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421190979,
-    "wof:lastmodified":1566609389,
+    "wof:lastmodified":1582318195,
     "wof:name":"Sherpur",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/191/607/421191607.geojson
+++ b/data/421/191/607/421191607.geojson
@@ -177,6 +177,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009698,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78f47f869b8874541b9e20de62fb2807",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421191607,
-    "wof:lastmodified":1566609388,
+    "wof:lastmodified":1582318195,
     "wof:name":"Nawabganj",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/191/661/421191661.geojson
+++ b/data/421/191/661/421191661.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009700,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1779b8c77ee26b06d7a5ceda8ebac1c",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":421191661,
-    "wof:lastmodified":1566609387,
+    "wof:lastmodified":1582318195,
     "wof:name":"Meherpur",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/191/663/421191663.geojson
+++ b/data/421/191/663/421191663.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009700,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5427ec8684e71e787a4805519939c838",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421191663,
-    "wof:lastmodified":1566609388,
+    "wof:lastmodified":1582318195,
     "wof:name":"Naogaon",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/191/745/421191745.geojson
+++ b/data/421/191/745/421191745.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009704,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef0484e72b9cc5938c27591db3dbb395",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":421191745,
-    "wof:lastmodified":1566609389,
+    "wof:lastmodified":1582318195,
     "wof:name":"Manikganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/191/923/421191923.geojson
+++ b/data/421/191/923/421191923.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009714,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f40b91a9b02da4f22a100a875d237ed2",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":421191923,
-    "wof:lastmodified":1566609387,
+    "wof:lastmodified":1582318195,
     "wof:name":"Jamalpur",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/194/153/421194153.geojson
+++ b/data/421/194/153/421194153.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009795,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb2c8211698fe63ba2efd216366df545",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421194153,
-    "wof:lastmodified":1566609369,
+    "wof:lastmodified":1582318192,
     "wof:name":"Chuadanga",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/194/867/421194867.geojson
+++ b/data/421/194/867/421194867.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9946d83ac63974d810a0bfe4afe544b9",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421194867,
-    "wof:lastmodified":1566609369,
+    "wof:lastmodified":1582318192,
     "wof:name":"Gopalganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/197/027/421197027.geojson
+++ b/data/421/197/027/421197027.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009900,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"436e46d1a93e17ee9db7f8d7ae2f6a3c",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":421197027,
-    "wof:lastmodified":1566609390,
+    "wof:lastmodified":1582318195,
     "wof:name":"Kaptaimukh",
     "wof:parent_id":421188983,
     "wof:placetype":"locality",

--- a/data/421/197/045/421197045.geojson
+++ b/data/421/197/045/421197045.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61e50cbf8f0aa6c0615bb1768bf30309",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421197045,
-    "wof:lastmodified":1566609389,
+    "wof:lastmodified":1582318195,
     "wof:name":"Narayanganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/197/541/421197541.geojson
+++ b/data/421/197/541/421197541.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009917,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c21099c6f745cfe1f4e3d5b410aed896",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421197541,
-    "wof:lastmodified":1566609390,
+    "wof:lastmodified":1582318195,
     "wof:name":"Pabna",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/198/063/421198063.geojson
+++ b/data/421/198/063/421198063.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459009935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e505d424501134daa8b7328d7717939",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421198063,
-    "wof:lastmodified":1566609386,
+    "wof:lastmodified":1582318195,
     "wof:name":"Faridpur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/200/811/421200811.geojson
+++ b/data/421/200/811/421200811.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010042,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0c274ef6313830214d0cb2fb759bdd3",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421200811,
-    "wof:lastmodified":1566609392,
+    "wof:lastmodified":1582318196,
     "wof:name":"Netrakona",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/201/541/421201541.geojson
+++ b/data/421/201/541/421201541.geojson
@@ -186,6 +186,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bc203f3d39d56c64e9739f57dd4b4ab",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":421201541,
-    "wof:lastmodified":1566609394,
+    "wof:lastmodified":1582318196,
     "wof:name":"Chittagong",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/201/927/421201927.geojson
+++ b/data/421/201/927/421201927.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010092,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d14f21fdf26fdc327bb5141861ff1a0",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421201927,
-    "wof:lastmodified":1566609393,
+    "wof:lastmodified":1582318196,
     "wof:name":"Satkhira",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/201/929/421201929.geojson
+++ b/data/421/201/929/421201929.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010092,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a413b84fe83197bbd34204544ffb9d59",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":421201929,
-    "wof:lastmodified":1566609393,
+    "wof:lastmodified":1582318196,
     "wof:name":"Sirajganj",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/201/931/421201931.geojson
+++ b/data/421/201/931/421201931.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010092,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3339e6b44660bf8b5e7fee63ba69c84f",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421201931,
-    "wof:lastmodified":1566609392,
+    "wof:lastmodified":1582318196,
     "wof:name":"Sunamganj",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/203/493/421203493.geojson
+++ b/data/421/203/493/421203493.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010154,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95c010fa20fc7a23bd1fd8e03bc6801c",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421203493,
-    "wof:lastmodified":1566609374,
+    "wof:lastmodified":1582318193,
     "wof:name":"Gazipur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/205/057/421205057.geojson
+++ b/data/421/205/057/421205057.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010210,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64efc9fa663fee20bd312ae7c2629b7b",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421205057,
-    "wof:lastmodified":1566609375,
+    "wof:lastmodified":1582318193,
     "wof:name":"Cox's Bazar",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/205/059/421205059.geojson
+++ b/data/421/205/059/421205059.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010211,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12b89095d6040065040c84a5c11ddda0",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421205059,
-    "wof:lastmodified":1566609375,
+    "wof:lastmodified":1582318193,
     "wof:name":"Munshiganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/205/213/421205213.geojson
+++ b/data/421/205/213/421205213.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"BD",
     "wof:created":1459010215,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e1c6f62f547fee31d60d764c6820f00",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":421205213,
-    "wof:lastmodified":1566609375,
+    "wof:lastmodified":1582318193,
     "wof:name":"Narail",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/856/324/75/85632475.geojson
+++ b/data/856/324/75/85632475.geojson
@@ -1043,8 +1043,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1098,6 +1099,11 @@
     },
     "wof:country":"BD",
     "wof:country_alpha3":"BGD",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"f1991a986281fd28138d60aae25b2d8d",
     "wof:hierarchy":[
         {
@@ -1112,7 +1118,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606662,
+    "wof:lastmodified":1582318150,
     "wof:name":"Bangladesh",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/75/85632475.geojson
+++ b/data/856/324/75/85632475.geojson
@@ -1044,7 +1044,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1118,7 +1117,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1582318150,
+    "wof:lastmodified":1583204779,
     "wof:name":"Bangladesh",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/690/09/85669009.geojson
+++ b/data/856/690/09/85669009.geojson
@@ -320,6 +320,9 @@
         "wk:page":"Dhaka Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b008965699a24f63998379673dc69192",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606669,
+    "wof:lastmodified":1582318154,
     "wof:name":"Dhaka",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/15/85669015.geojson
+++ b/data/856/690/15/85669015.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Khulna Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ca0e8050556ecc0a037aac13258fde5",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606670,
+    "wof:lastmodified":1582318155,
     "wof:name":"Khulna",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/19/85669019.geojson
+++ b/data/856/690/19/85669019.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Barisal Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3433bf2bb801d08810d9db2475a4bd98",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606668,
+    "wof:lastmodified":1582318153,
     "wof:name":"Barisal",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/23/85669023.geojson
+++ b/data/856/690/23/85669023.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Chittagong Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b1f9681bba2e45e9b171a500a125d8a",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606669,
+    "wof:lastmodified":1582318154,
     "wof:name":"Chittagong",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/25/85669025.geojson
+++ b/data/856/690/25/85669025.geojson
@@ -267,6 +267,9 @@
         "wk:page":"Sylhet Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8f68a6e5f709ed79f6bcf3bc8d0b1bd",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606671,
+    "wof:lastmodified":1582318155,
     "wof:name":"Sylhet",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/31/85669031.geojson
+++ b/data/856/690/31/85669031.geojson
@@ -262,6 +262,9 @@
         "wk:page":"Rajshahi Division"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c02bed79ddf822d6d837a89051c70686",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606669,
+    "wof:lastmodified":1582318154,
     "wof:name":"Rajshahi",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/35/85669035.geojson
+++ b/data/856/690/35/85669035.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q402021"
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d89cce074bd25a969ab7fe0d485fff04",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1566606666,
+    "wof:lastmodified":1582318152,
     "wof:name":"Rangpur",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/859/029/71/85902971.geojson
+++ b/data/859/029/71/85902971.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":235464
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79074e8a92913203369afc2e3c69b22e",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566606661,
+    "wof:lastmodified":1582318148,
     "wof:name":"Amla Para",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/73/85902973.geojson
+++ b/data/859/029/73/85902973.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":1083622
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecd072dd3466489cc33e28da37b45057",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566606661,
+    "wof:lastmodified":1582318148,
     "wof:name":"Ramna Maidan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/77/85902977.geojson
+++ b/data/859/029/77/85902977.geojson
@@ -72,6 +72,9 @@
         "gp:id":1911037
     },
     "wof:country":"BD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6697c9b2ab8ed0ae5c90bc21e6d0d28c",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566606661,
+    "wof:lastmodified":1582318148,
     "wof:name":"Sadar Gh\u00e5t",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/438/075/890438075.geojson
+++ b/data/890/438/075/890438075.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"BD",
     "wof:created":1469052179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a45cfbe2af748970f3904e8f1c98ac4f",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":890438075,
-    "wof:lastmodified":1566609402,
+    "wof:lastmodified":1582318198,
     "wof:name":"Kushtia",
     "wof:parent_id":85669015,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.