### PR TITLE
bd concordances, placetype local, and more

### DIFF
--- a/data/110/869/466/7/1108694667.geojson
+++ b/data/110/869/466/7/1108694667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170155,
-    "geom:area_square_m":1922818486.350508,
+    "geom:area_square_m":1922818430.446941,
     "geom:bbox":"90.722683,23.645687,91.329628,24.26925",
     "geom:latitude":23.95148,
     "geom:longitude":91.08545,
@@ -153,9 +153,10 @@
         "hasc:id":"BD.CG.BB",
         "wd:id":"Q897330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474492983,
-    "wof:geomhash":"508c72bc3f321fa487c07120d9460472",
+    "wof:geomhash":"06a1803d5d1aee4a175278e74a28ea17",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108694667,
-    "wof:lastmodified":1690856095,
+    "wof:lastmodified":1695886813,
     "wof:name":"Brahamanbaria",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/110/869/466/9/1108694669.geojson
+++ b/data/110/869/466/9/1108694669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149708,
-    "geom:area_square_m":1700711503.7622,
+    "geom:area_square_m":1700711812.207829,
     "geom:bbox":"90.539196,22.987232,91.031527,23.503034",
     "geom:latitude":23.259668,
     "geom:longitude":90.753528,
@@ -155,9 +155,10 @@
         "hasc:id":"BD.CG.CP",
         "wd:id":"Q1429697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474492985,
-    "wof:geomhash":"13ae29effa8070edc55d430594ac3f20",
+    "wof:geomhash":"7c8732c3bef60c21bfd8216843eb469a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1108694669,
-    "wof:lastmodified":1690856094,
+    "wof:lastmodified":1695886813,
     "wof:name":"Chandpur",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/110/869/467/1/1108694671.geojson
+++ b/data/110/869/467/1/1108694671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309938,
-    "geom:area_square_m":3455321240.105085,
+    "geom:area_square_m":3455321295.53826,
     "geom:bbox":"88.382314,25.225967,89.304566,26.059657",
     "geom:latitude":25.630539,
     "geom:longitude":88.787803,
@@ -167,9 +167,10 @@
         "hasc:id":"BD.RP.DJ",
         "wd:id":"Q1985120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474492991,
-    "wof:geomhash":"1660805e06cf725031d75af0ae4de8d2",
+    "wof:geomhash":"1f4b0a6cd3e183aee5618626761527f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1108694671,
-    "wof:lastmodified":1690856091,
+    "wof:lastmodified":1695886812,
     "wof:name":"Dinajpur",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/467/5/1108694675.geojson
+++ b/data/110/869/467/5/1108694675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195022,
-    "geom:area_square_m":2180199669.511184,
+    "geom:area_square_m":2180199644.937555,
     "geom:bbox":"89.185014,25.035928,89.758754,25.64313",
     "geom:latitude":25.298413,
     "geom:longitude":89.509023,
@@ -162,9 +162,10 @@
         "hasc:id":"BD.RP.GB",
         "wd:id":"Q2344595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474492995,
-    "wof:geomhash":"b116cb54ee902da0cd96117ec9d9b101",
+    "wof:geomhash":"bebefb1dd4194af62b7d096de0a5ffa3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108694675,
-    "wof:lastmodified":1690856091,
+    "wof:lastmodified":1695886812,
     "wof:name":"Gaibandha",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/467/7/1108694677.geojson
+++ b/data/110/869/467/7/1108694677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062833,
-    "geom:area_square_m":717413341.18354,
+    "geom:area_square_m":717413747.282061,
     "geom:bbox":"90.020868,22.344208,90.390822,22.78425",
     "geom:latitude":22.574676,
     "geom:longitude":90.186137,
@@ -141,9 +141,10 @@
         "hasc:id":"BD.BA.JK",
         "wd:id":"Q2093327"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493000,
-    "wof:geomhash":"41089697b61d63eb5664990e1c711ba5",
+    "wof:geomhash":"61320c3590ea33ffac6752a23231d4f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108694677,
-    "wof:lastmodified":1690856091,
+    "wof:lastmodified":1695886812,
     "wof:name":"Jhalokati",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/110/869/467/9/1108694679.geojson
+++ b/data/110/869/467/9/1108694679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172937,
-    "geom:area_square_m":1961254766.458385,
+    "geom:area_square_m":1961255176.382295,
     "geom:bbox":"88.697679,23.217704,89.378781,23.769229",
     "geom:latitude":23.485594,
     "geom:longitude":89.089155,
@@ -146,9 +146,10 @@
         "hasc:id":"BD.KH.JN",
         "wd:id":"Q2188750"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493002,
-    "wof:geomhash":"72130667fc086172bd8bc3e98d59869d",
+    "wof:geomhash":"49f0de23cf0584afea51baddcc92bfcb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108694679,
-    "wof:lastmodified":1690856090,
+    "wof:lastmodified":1695886812,
     "wof:name":"Jhenaidah",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/110/869/468/1/1108694681.geojson
+++ b/data/110/869/468/1/1108694681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087796,
-    "geom:area_square_m":983104818.430991,
+    "geom:area_square_m":983105298.593998,
     "geom:bbox":"88.880046,24.855381,89.278015,25.276321",
     "geom:latitude":25.099278,
     "geom:longitude":89.079656,
@@ -147,9 +147,10 @@
         "hasc:id":"BD.RS.JP",
         "wd:id":"Q2348146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493003,
-    "wof:geomhash":"2afb7318c5a4e50ce1bd7e94de3cec71",
+    "wof:geomhash":"596e19a481d8677982c5df53aa8275a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108694681,
-    "wof:lastmodified":1690856093,
+    "wof:lastmodified":1695886812,
     "wof:name":"Joypurhat",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/110/869/468/3/1108694683.geojson
+++ b/data/110/869/468/3/1108694683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232994,
-    "geom:area_square_m":2648789704.578032,
+    "geom:area_square_m":2648789212.349741,
     "geom:bbox":"91.712722,22.692733,92.155285,23.734064",
     "geom:latitude":23.161206,
     "geom:longitude":91.940585,
@@ -150,9 +150,10 @@
         "hasc:id":"BD.CG.KG",
         "wd:id":"Q1429685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493005,
-    "wof:geomhash":"01820c68be35be819e260e5e66258c49",
+    "wof:geomhash":"6911f256d7456659290756ea5397eb4f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108694683,
-    "wof:lastmodified":1690856094,
+    "wof:lastmodified":1695886813,
     "wof:name":"Khagrachhari",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/110/869/468/5/1108694685.geojson
+++ b/data/110/869/468/5/1108694685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203415,
-    "geom:area_square_m":2264707206.865183,
+    "geom:area_square_m":2264707003.299905,
     "geom:bbox":"89.458201,25.374252,89.889671,26.237582",
     "geom:latitude":25.790748,
     "geom:longitude":89.698552,
@@ -161,9 +161,10 @@
         "hasc:id":"BD.RP.KR",
         "wd:id":"Q2348751"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493008,
-    "wof:geomhash":"e0fb9b782252a05576fe8d45b873ecf8",
+    "wof:geomhash":"3307d717c7a7233d50c28265d21f2414",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1108694685,
-    "wof:lastmodified":1690856094,
+    "wof:lastmodified":1695886813,
     "wof:name":"Kurigram",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/468/7/1108694687.geojson
+++ b/data/110/869/468/7/1108694687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110388,
-    "geom:area_square_m":1226164996.366975,
+    "geom:area_square_m":1226165398.249036,
     "geom:bbox":"88.908458,25.790158,89.563106,26.457525",
     "geom:latitude":26.063035,
     "geom:longitude":89.240018,
@@ -152,9 +152,10 @@
         "hasc:id":"BD.RP.LL",
         "wd:id":"Q2373734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493017,
-    "wof:geomhash":"30c3aef39c2c17489f396fc810c7cf85",
+    "wof:geomhash":"afd5917e6fd112043e23541f5295ff4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1108694687,
-    "wof:lastmodified":1690856093,
+    "wof:lastmodified":1695886813,
     "wof:name":"Lalmonirhat",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/468/9/1108694689.geojson
+++ b/data/110/869/468/9/1108694689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092352,
-    "geom:area_square_m":1047729277.231801,
+    "geom:area_square_m":1047729372.472764,
     "geom:bbox":"89.248761,23.250424,89.63697,23.675438",
     "geom:latitude":23.438128,
     "geom:longitude":89.435223,
@@ -161,9 +161,10 @@
         "hasc:id":"BD.KH.MG",
         "wd:id":"Q2039085"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493019,
-    "wof:geomhash":"6de62a19d12dd2a173e6976ec2bfdc4e",
+    "wof:geomhash":"0c80b1a7e294b58c049ce8a2b232c23c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1108694689,
-    "wof:lastmodified":1690856093,
+    "wof:lastmodified":1695886812,
     "wof:name":"Magura",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/110/869/469/3/1108694693.geojson
+++ b/data/110/869/469/3/1108694693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241731,
-    "geom:area_square_m":2720383749.304398,
+    "geom:area_square_m":2720383787.746243,
     "geom:bbox":"91.597095,24.136164,92.291745,24.831867",
     "geom:latitude":24.478355,
     "geom:longitude":91.916004,
@@ -154,9 +154,10 @@
         "hasc:id":"BD.SY.MB",
         "wd:id":"Q281435"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493022,
-    "wof:geomhash":"6c41109d76bc212f93c85e34aa75e614",
+    "wof:geomhash":"de8361a0283dd46c4f0a06b658d728f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108694693,
-    "wof:lastmodified":1690856092,
+    "wof:lastmodified":1695886812,
     "wof:name":"Maulvibazar",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/110/869/469/5/1108694695.geojson
+++ b/data/110/869/469/5/1108694695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149806,
-    "geom:area_square_m":1664573945.369908,
+    "geom:area_square_m":1664573649.205603,
     "geom:bbox":"88.737876,25.739304,89.196511,26.309501",
     "geom:latitude":26.023697,
     "geom:longitude":88.940098,
@@ -149,9 +149,10 @@
         "hasc:id":"BD.RP.NP",
         "wd:id":"Q2188627"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493033,
-    "wof:geomhash":"4b7c192c621a70a9ff646f545462315f",
+    "wof:geomhash":"32161a520a54043b8df02287e8244c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108694695,
-    "wof:lastmodified":1690856092,
+    "wof:lastmodified":1695886812,
     "wof:name":"Nilphamari",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/469/7/1108694697.geojson
+++ b/data/110/869/469/7/1108694697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125421,
-    "geom:area_square_m":1390488307.18879,
+    "geom:area_square_m":1390488651.56742,
     "geom:bbox":"88.321808,26.006139,88.797896,26.634149",
     "geom:latitude":26.285846,
     "geom:longitude":88.581092,
@@ -155,9 +155,10 @@
         "hasc:id":"BD.RP.PN",
         "wd:id":"Q2367822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493036,
-    "wof:geomhash":"0855e26e1540e67efa4c9528f098246c",
+    "wof:geomhash":"2285a2a5f70591c6a37f74d67ed0644f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1108694697,
-    "wof:lastmodified":1690856092,
+    "wof:lastmodified":1695886812,
     "wof:name":"Panchagarh",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/469/9/1108694699.geojson
+++ b/data/110/869/469/9/1108694699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099384,
-    "geom:area_square_m":1125048391.713553,
+    "geom:area_square_m":1125048088.790178,
     "geom:bbox":"89.298725,23.566997,89.869552,23.907982",
     "geom:latitude":23.72497,
     "geom:longitude":89.56204,
@@ -149,9 +149,10 @@
         "hasc:id":"BD.DH.RB",
         "wd:id":"Q2348762"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493040,
-    "wof:geomhash":"4d192b8f5377025c85f83486949b5d26",
+    "wof:geomhash":"c80a6db38a58d30067a139c7519dade1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108694699,
-    "wof:lastmodified":1690856092,
+    "wof:lastmodified":1695886812,
     "wof:name":"Rajbari",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/110/869/470/1/1108694701.geojson
+++ b/data/110/869/470/1/1108694701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209058,
-    "geom:area_square_m":2330397786.915917,
+    "geom:area_square_m":2330397656.975904,
     "geom:bbox":"88.92725,25.300789,89.538078,25.948942",
     "geom:latitude":25.644848,
     "geom:longitude":89.240952,
@@ -210,9 +210,10 @@
         "hasc:id":"BD.RP.RP",
         "wd:id":"Q2344570"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493043,
-    "wof:geomhash":"03938598849b7c5d4122a591fb3c09e9",
+    "wof:geomhash":"2cec2501bbe06ad44220d35fe82b7d87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":1108694701,
-    "wof:lastmodified":1690856090,
+    "wof:lastmodified":1695886655,
     "wof:name":"Rangpur",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/869/470/3/1108694703.geojson
+++ b/data/110/869/470/3/1108694703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16335,
-    "geom:area_square_m":1815569651.816185,
+    "geom:area_square_m":1815569480.408657,
     "geom:bbox":"88.088999,25.66736,88.641933,26.214196",
     "geom:latitude":25.990865,
     "geom:longitude":88.34777,
@@ -152,9 +152,10 @@
         "hasc:id":"BD.RP.TH",
         "wd:id":"Q2367825"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1474493051,
-    "wof:geomhash":"d7227b4fcf6001997587abb59a403d0d",
+    "wof:geomhash":"fa18c8379a39955706ae6c1344c8bc7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1108694703,
-    "wof:lastmodified":1690856090,
+    "wof:lastmodified":1695886812,
     "wof:name":"Thakurgaon",
     "wof:parent_id":85669035,
     "wof:placetype":"county",

--- a/data/110/880/310/1/1108803101.geojson
+++ b/data/110/880/310/1/1108803101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.940398,
-    "geom:area_square_m":10551813598.542303,
+    "geom:area_square_m":10551814753.271008,
     "geom:bbox":"89.643176,24.247401,91.240831,25.432043",
     "geom:latitude":24.84595,
     "geom:longitude":90.385698,
@@ -23,7 +23,7 @@
     "lbl:longitude":90.464141,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:aka_x_preferred":[
@@ -179,11 +179,13 @@
     "wof:concordances":{
         "fips:code":"BG81",
         "hasc:id":"BD.MM",
+        "iso:code":"BD-C",
         "iso:id":"BD-C"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:created":1485221873,
-    "wof:geomhash":"a02f5f21424793b94630816726005306",
+    "wof:geomhash":"4bbf02fa8a9e292f15e64ec25aae3054",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +200,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1636495530,
+    "wof:lastmodified":1695884286,
     "wof:name":"Mymensingh",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/421/166/521/421166521.geojson
+++ b/data/421/166/521/421166521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105687,
-    "geom:area_square_m":1203854851.689504,
+    "geom:area_square_m":1203854487.752465,
     "geom:bbox":"90.644252,22.575728,91.004582,23.166655",
     "geom:latitude":22.898848,
     "geom:longitude":90.853516,
@@ -178,12 +178,13 @@
         "wd:id":"Q1550252",
         "wk:page":"Lakshmipur District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008693,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f320ee6e2ee51b09af4af5dab6263bd1",
+    "wof:geomhash":"a8a7b40b324ab8e8b4c372d2f7b962ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421166521,
-    "wof:lastmodified":1690856100,
+    "wof:lastmodified":1695886588,
     "wof:name":"Lakshmipur",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/169/477/421169477.geojson
+++ b/data/421/169/477/421169477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.433646,
-    "geom:area_square_m":4978534461.425696,
+    "geom:area_square_m":4978535193.197032,
     "geom:bbox":"92.036743,21.177528,92.683448,22.381197",
     "geom:latitude":21.801541,
     "geom:longitude":92.347581,
@@ -177,12 +177,13 @@
         "qs_pg:id":1190324,
         "wd:id":"Q806273"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008811,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c99083d62f1bfd67ed0bca41252d18b",
+    "wof:geomhash":"c469c41ed3bf38a7ec94f5d973553d8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":421169477,
-    "wof:lastmodified":1690856103,
+    "wof:lastmodified":1695886589,
     "wof:name":"Bandarban",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/169/707/421169707.geojson
+++ b/data/421/169/707/421169707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103289,
-    "geom:area_square_m":1166728624.166968,
+    "geom:area_square_m":1166728641.323935,
     "geom:bbox":"90.560568,23.784098,90.988507,24.250126",
     "geom:latitude":24.004128,
     "geom:longitude":90.775978,
@@ -181,12 +181,13 @@
         "qs_pg:id":230091,
         "wd:id":"Q2042638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008821,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d11ee7873e9244f99547b753f86b2d25",
+    "wof:geomhash":"2e995dbc12bfa264f05298716428bf24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421169707,
-    "wof:lastmodified":1690856103,
+    "wof:lastmodified":1695886588,
     "wof:name":"Narsingdi",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/169/845/421169845.geojson
+++ b/data/421/169/845/421169845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215494,
-    "geom:area_square_m":2467345665.410275,
+    "geom:area_square_m":2467347093.73568,
     "geom:bbox":"90.086361,21.76194,90.683054,22.615506",
     "geom:latitude":22.184875,
     "geom:longitude":90.405824,
@@ -168,12 +168,13 @@
         "qs_pg:id":1268227,
         "wd:id":"Q1429761"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008826,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fda6e4b0c5cc70b4a1c52ae1277da24",
+    "wof:geomhash":"e471e811789b82aabd935b6da5c39372",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421169845,
-    "wof:lastmodified":1690856103,
+    "wof:lastmodified":1695886588,
     "wof:name":"Patuakhali",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/170/483/421170483.geojson
+++ b/data/421/170/483/421170483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223587,
-    "geom:area_square_m":2518312946.81039,
+    "geom:area_square_m":2518313041.521683,
     "geom:bbox":"90.57663,24.038344,91.255628,24.633847",
     "geom:latitude":24.37242,
     "geom:longitude":90.944409,
@@ -179,12 +179,13 @@
         "qs_pg:id":483047,
         "wd:id":"Q2344833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008855,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36de27f0e7c0d3b00ec3c898ff03ac49",
+    "wof:geomhash":"2538641cb877f93915cb814dafb86c6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":421170483,
-    "wof:lastmodified":1690856119,
+    "wof:lastmodified":1695886592,
     "wof:name":"Kishoreganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/172/031/421172031.geojson
+++ b/data/421/172/031/421172031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097535,
-    "geom:area_square_m":1113901855.683256,
+    "geom:area_square_m":1113901358.24291,
     "geom:bbox":"89.855354,22.156298,90.190073,22.866423",
     "geom:latitude":22.540117,
     "geom:longitude":90.001074,
@@ -175,12 +175,13 @@
         "wd:id":"Q609190",
         "wk:page":"Pirojpur District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008916,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c3f3e51c300a10f6928b79bed47e597",
+    "wof:geomhash":"be63b2bed792ce8c25907cb723523260",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":421172031,
-    "wof:lastmodified":1690856110,
+    "wof:lastmodified":1695886591,
     "wof:name":"Pirojpur",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/172/439/421172439.geojson
+++ b/data/421/172/439/421172439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211908,
-    "geom:area_square_m":2384945618.957357,
+    "geom:area_square_m":2384945757.482082,
     "geom:bbox":"88.303865,24.119159,88.964068,24.717189",
     "geom:latitude":24.468378,
     "geom:longitude":88.656343,
@@ -233,12 +233,13 @@
         "qs_pg:id":1310794,
         "wd:id":"Q2344697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459008942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48c85a44c3946c05e19129275fe27196",
+    "wof:geomhash":"73ff64e4e1157eda00bac1936ca54076",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -248,7 +249,7 @@
         }
     ],
     "wof:id":421172439,
-    "wof:lastmodified":1690856110,
+    "wof:lastmodified":1695886656,
     "wof:name":"Rajshahi",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/176/039/421176039.geojson
+++ b/data/421/176/039/421176039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224027,
-    "geom:area_square_m":2548257631.385668,
+    "geom:area_square_m":2548256916.264602,
     "geom:bbox":"88.847969,22.792541,89.56958,23.375356",
     "geom:latitude":23.087554,
     "geom:longitude":89.176665,
@@ -202,12 +202,13 @@
         "qs_pg:id":1330373,
         "wd:id":"Q1862981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009088,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5567f4992cbe433599e644bb054ab1b0",
+    "wof:geomhash":"560a869538b028f5a04cd22f03fa3a54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":421176039,
-    "wof:lastmodified":1690856122,
+    "wof:lastmodified":1695886593,
     "wof:name":"Jessore",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/176/043/421176043.geojson
+++ b/data/421/176/043/421176043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116151,
-    "geom:area_square_m":1330328926.273252,
+    "geom:area_square_m":1330328472.54401,
     "geom:bbox":"89.904135,21.859353,90.375709,22.483308",
     "geom:latitude":22.139353,
     "geom:longitude":90.125978,
@@ -191,12 +191,13 @@
         "wd:id":"Q808172",
         "wk:page":"Barguna District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009088,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c131f35d66979133abf4f7fadea8666",
+    "wof:geomhash":"5e495cfd215f95dd508712ce814554bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421176043,
-    "wof:lastmodified":1690856122,
+    "wof:lastmodified":1695886593,
     "wof:name":"Barguna",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/176/045/421176045.geojson
+++ b/data/421/176/045/421176045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230126,
-    "geom:area_square_m":2592024994.961697,
+    "geom:area_square_m":2592024808.918652,
     "geom:bbox":"91.151234,23.974533,91.701927,24.694336",
     "geom:latitude":24.36909,
     "geom:longitude":91.431173,
@@ -185,12 +185,13 @@
         "wd:id":"Q1438974",
         "wk:page":"Habiganj District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009088,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"397f695211e66f8db956a7f6b4cbe4ea",
+    "wof:geomhash":"df1547607ade2475ad7cea38b6f0a234",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421176045,
-    "wof:lastmodified":1690856122,
+    "wof:lastmodified":1695886594,
     "wof:name":"Habiganj",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/177/051/421177051.geojson
+++ b/data/421/177/051/421177051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231593,
-    "geom:area_square_m":2641844842.702941,
+    "geom:area_square_m":2641845096.254413,
     "geom:bbox":"90.891853,22.022306,91.413332,23.13252",
     "geom:latitude":22.699434,
     "geom:longitude":91.127201,
@@ -185,12 +185,13 @@
         "qs_pg:id":400650,
         "wd:id":"Q68585"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009131,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7c07cfced85327270421b32444d9555",
+    "wof:geomhash":"a3fcb671eb5ac22f1563979509b9ce9a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421177051,
-    "wof:lastmodified":1690856120,
+    "wof:lastmodified":1695886594,
     "wof:name":"Noakhali",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/181/771/421181771.geojson
+++ b/data/421/181/771/421181771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080291,
-    "geom:area_square_m":913899622.654347,
+    "geom:area_square_m":913899611.207766,
     "geom:bbox":"91.249576,22.750761,91.581234,23.284422",
     "geom:latitude":22.997609,
     "geom:longitude":91.415453,
@@ -178,12 +178,13 @@
         "wd:id":"Q1404741",
         "wk:page":"Feni District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009306,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c987baf65cbdb86687fb1dbfc9211cc0",
+    "wof:geomhash":"3467c48bebe1b4719c17cda2b95f2274",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421181771,
-    "wof:lastmodified":1690856111,
+    "wof:lastmodified":1695886591,
     "wof:name":"Feni",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/182/115/421182115.geojson
+++ b/data/421/182/115/421182115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170295,
-    "geom:area_square_m":1917940288.766893,
+    "geom:area_square_m":1917939970.568038,
     "geom:bbox":"88.845687,24.105477,89.340513,24.658899",
     "geom:latitude":24.380646,
     "geom:longitude":89.087663,
@@ -179,12 +179,13 @@
         "qs_pg:id":888977,
         "wd:id":"Q2093361"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009319,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a296fa8feb78125d218dc599b3c077d2",
+    "wof:geomhash":"797277dd7e2961b77f37fb7f7e570efa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":421182115,
-    "wof:lastmodified":1690856121,
+    "wof:lastmodified":1695886594,
     "wof:name":"Natore",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/183/929/421183929.geojson
+++ b/data/421/183/929/421183929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098665,
-    "geom:area_square_m":1121243110.552334,
+    "geom:area_square_m":1121243425.429548,
     "geom:bbox":"89.938014,22.963174,90.356569,23.506929",
     "geom:latitude":23.213052,
     "geom:longitude":90.166401,
@@ -182,12 +182,13 @@
         "qs_pg:id":986232,
         "wd:id":"Q928836"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009395,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d11b760ba7a9dc750d5b0bd57ce16fa",
+    "wof:geomhash":"acf8fb8763469eb360f8034fac1e9e9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":421183929,
-    "wof:lastmodified":1690856121,
+    "wof:lastmodified":1695886594,
     "wof:name":"Madaripur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/184/491/421184491.geojson
+++ b/data/421/184/491/421184491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175992,
-    "geom:area_square_m":2012785021.995933,
+    "geom:area_square_m":2012783447.092537,
     "geom:bbox":"90.539383,21.848535,91.040439,22.792506",
     "geom:latitude":22.343164,
     "geom:longitude":90.74966,
@@ -187,12 +187,13 @@
         "wd:id":"Q855042",
         "wk:page":"Bhola District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009412,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"817d49b0e22c4fda25a6037fd19770e2",
+    "wof:geomhash":"6e2eabce5e7e5f9a4c70df1c9588a64d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":421184491,
-    "wof:lastmodified":1690856118,
+    "wof:lastmodified":1695886592,
     "wof:name":"Bhola",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/185/469/421185469.geojson
+++ b/data/421/185/469/421185469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381433,
-    "geom:area_square_m":4285092274.056154,
+    "geom:area_square_m":4285092446.196591,
     "geom:bbox":"90.086792,24.247401,90.821533,25.197431",
     "geom:latitude":24.695644,
     "geom:longitude":90.431582,
@@ -182,12 +182,13 @@
         "wd:id":"Q1429976",
         "wk:page":"Mymensingh District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c865970fe90b0016cf92ecd56c1879ee",
+    "wof:geomhash":"87ac40d1944af9878e444e718e8a494b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":421185469,
-    "wof:lastmodified":1690856123,
+    "wof:lastmodified":1695886658,
     "wof:name":"Mymensingh",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/185/471/421185471.geojson
+++ b/data/421/185/471/421185471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307013,
-    "geom:area_square_m":3458397791.737265,
+    "geom:area_square_m":3458397728.086823,
     "geom:bbox":"89.721124,23.960848,90.301177,24.791218",
     "geom:latitude":24.355739,
     "geom:longitude":89.997683,
@@ -170,12 +170,13 @@
         "wd:id":"Q952184",
         "wk:page":"Tangail District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"969571fdcb13d87c199ac1102babf12d",
+    "wof:geomhash":"c990c8690eac4bb9d9974ce1aef6279a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421185471,
-    "wof:lastmodified":1690856123,
+    "wof:lastmodified":1695886657,
     "wof:name":"Tangail",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/185/473/421185473.geojson
+++ b/data/421/185/473/421185473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313089,
-    "geom:area_square_m":3577559331.687417,
+    "geom:area_square_m":3577558552.088358,
     "geom:bbox":"89.238643,21.695374,89.758914,23.008799",
     "geom:latitude":22.465025,
     "geom:longitude":89.449582,
@@ -199,12 +199,13 @@
         "wd:id":"Q2093344",
         "wk:page":"Khulna District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f724082a9806f839374fd9190ac37d37",
+    "wof:geomhash":"3b880773c06f088e8cf1803d04909e03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":421185473,
-    "wof:lastmodified":1690856123,
+    "wof:lastmodified":1695886657,
     "wof:name":"Khulna",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/187/745/421187745.geojson
+++ b/data/421/187/745/421187745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.20137,
-    "geom:area_square_m":2295177776.212229,
+    "geom:area_square_m":2295177014.152854,
     "geom:bbox":"90.017683,22.454337,90.691394,23.100407",
     "geom:latitude":22.813886,
     "geom:longitude":90.354914,
@@ -240,12 +240,13 @@
         "qs_pg:id":1085898,
         "wd:id":"Q1763301"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009522,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"863854968898cc24ed5a12977208810b",
+    "wof:geomhash":"9b76edef1dbcc423416c8b19b3c55744",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -255,7 +256,7 @@
         }
     ],
     "wof:id":421187745,
-    "wof:lastmodified":1690856108,
+    "wof:lastmodified":1695886656,
     "wof:name":"Barisal",
     "wof:parent_id":85669019,
     "wof:placetype":"county",

--- a/data/421/187/747/421187747.geojson
+++ b/data/421/187/747/421187747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.320359,
-    "geom:area_square_m":3663249661.985754,
+    "geom:area_square_m":3663250772.075985,
     "geom:bbox":"89.533511,21.712769,89.983386,22.983299",
     "geom:latitude":22.365789,
     "geom:longitude":89.741924,
@@ -176,12 +176,13 @@
         "qs_pg:id":1085899,
         "wd:id":"Q2344861"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009523,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f6eef90468a45f3164af7f3263afab7c",
+    "wof:geomhash":"af833340027e6dfcffb6e5ef0d3f4525",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421187747,
-    "wof:lastmodified":1690856107,
+    "wof:lastmodified":1695886589,
     "wof:name":"Bagerhat",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/187/793/421187793.geojson
+++ b/data/421/187/793/421187793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259869,
-    "geom:area_square_m":2916347224.779384,
+    "geom:area_square_m":2916347002.983873,
     "geom:bbox":"88.965769,24.547858,89.749747,25.121579",
     "geom:latitude":24.827139,
     "geom:longitude":89.379253,
@@ -185,12 +185,13 @@
         "wd:id":"Q2039066",
         "wk:page":"Bogra District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009524,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64bb560a81d0fb22a9e021254a0075d4",
+    "wof:geomhash":"027f24037aee89315af5692cb7f25fe7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421187793,
-    "wof:lastmodified":1690856107,
+    "wof:lastmodified":1695886590,
     "wof:name":"Bogra",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/187/795/421187795.geojson
+++ b/data/421/187/795/421187795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305335,
-    "geom:area_square_m":3424015698.192631,
+    "geom:area_square_m":3424015577.158518,
     "geom:bbox":"91.638216,24.592598,92.501155,25.186429",
     "geom:latitude":24.919539,
     "geom:longitude":91.991441,
@@ -235,12 +235,13 @@
         "wd:id":"Q2093352",
         "wk:page":"Sylhet District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009524,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f23beb36aebd3c6c1b755145fd2c171c",
+    "wof:geomhash":"3c4e985cb92db66a3faa43e72b1c7f31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -250,7 +251,7 @@
         }
     ],
     "wof:id":421187795,
-    "wof:lastmodified":1690856107,
+    "wof:lastmodified":1695886656,
     "wof:name":"Sylhet",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/187/801/421187801.geojson
+++ b/data/421/187/801/421187801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.275652,
-    "geom:area_square_m":3127300985.631536,
+    "geom:area_square_m":3127300796.020488,
     "geom:bbox":"90.629716,23.044743,91.374844,23.796588",
     "geom:latitude":23.4354,
     "geom:longitude":91.036546,
@@ -191,12 +191,13 @@
         "wd:id":"Q1480778",
         "wk:page":"Comilla District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009524,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7daca39189f4127ca83937b3158156a5",
+    "wof:geomhash":"42507a64455ad4816b50b7fce4496dcf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421187801,
-    "wof:lastmodified":1690856108,
+    "wof:lastmodified":1695886656,
     "wof:name":"Comilla",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/187/803/421187803.geojson
+++ b/data/421/187/803/421187803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134782,
-    "geom:area_square_m":1524908764.266685,
+    "geom:area_square_m":1524908385.63869,
     "geom:bbox":"90.011436,23.526321,90.509888,24.043081",
     "geom:latitude":23.797116,
     "geom:longitude":90.25571,
@@ -214,12 +214,13 @@
         "wd:id":"Q1850485",
         "wk:page":"Dhaka District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009524,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4d4cde6ea09e034dedfd58b9837b742",
+    "wof:geomhash":"a1b7ee1da958c230176001ca153fe399",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":421187803,
-    "wof:lastmodified":1690856106,
+    "wof:lastmodified":1695886656,
     "wof:name":"Dhaka",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/188/359/421188359.geojson
+++ b/data/421/188/359/421188359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109821,
-    "geom:area_square_m":1247618246.272472,
+    "geom:area_square_m":1247618232.900337,
     "geom:bbox":"90.201473,23.007084,90.613702,23.462941",
     "geom:latitude":23.25659,
     "geom:longitude":90.411637,
@@ -170,12 +170,13 @@
         "qs_pg:id":22416,
         "wd:id":"Q253007"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009543,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34d9a0a6e225909130ede30699ffd9cb",
+    "wof:geomhash":"e9fc0c864dbe6423cc8dd33a72b10ad8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421188359,
-    "wof:lastmodified":1690856109,
+    "wof:lastmodified":1695886591,
     "wof:name":"Shariatpur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/188/983/421188983.geojson
+++ b/data/421/188/983/421188983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.533375,
-    "geom:area_square_m":6077925259.320327,
+    "geom:area_square_m":6077925563.97137,
     "geom:bbox":"91.920884,21.909044,92.627166,23.739019",
     "geom:latitude":22.84183,
     "geom:longitude":92.27501,
@@ -191,12 +191,13 @@
         "qs_pg:id":1190323,
         "wd:id":"Q2121686"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009595,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09a3a14a56abea36894e680484547c16",
+    "wof:geomhash":"ec13954e8cc4bb57ad153ae433dac21f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421188983,
-    "wof:lastmodified":1690856109,
+    "wof:lastmodified":1695886591,
     "wof:name":"Rangamati",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/190/979/421190979.geojson
+++ b/data/421/190/979/421190979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117962,
-    "geom:area_square_m":1321056268.140466,
+    "geom:area_square_m":1321056157.118459,
     "geom:bbox":"89.881029,24.883183,90.309621,25.303129",
     "geom:latitude":25.084321,
     "geom:longitude":90.078093,
@@ -176,12 +176,13 @@
         "wd:id":"Q2039314",
         "wk:page":"Sherpur District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009675,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b677f50e10ab050c489171c2dc1d17d",
+    "wof:geomhash":"05a92e0fc97cf51907e8e1423b3eaee3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421190979,
-    "wof:lastmodified":1690856115,
+    "wof:lastmodified":1695886591,
     "wof:name":"Sherpur",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/191/607/421191607.geojson
+++ b/data/421/191/607/421191607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153333,
-    "geom:area_square_m":1722409025.474108,
+    "geom:area_square_m":1722409044.664169,
     "geom:bbox":"88.01143,24.371573,88.511555,24.96724",
     "geom:latitude":24.707833,
     "geom:longitude":88.268302,
@@ -191,12 +191,13 @@
         "qs_pg:id":69611,
         "wd:id":"Q46043"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009698,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3496615e2807e92fee3e999c22ef490c",
+    "wof:geomhash":"a90cfaa67b1c087777121d2e6e6dc70f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421191607,
-    "wof:lastmodified":1690856114,
+    "wof:lastmodified":1695886656,
     "wof:name":"Nawabganj",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/191/661/421191661.geojson
+++ b/data/421/191/661/421191661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064205,
-    "geom:area_square_m":726413371.16401,
+    "geom:area_square_m":726413223.674125,
     "geom:bbox":"88.559091,23.599075,88.889576,23.978488",
     "geom:latitude":23.795527,
     "geom:longitude":88.711144,
@@ -184,12 +184,13 @@
         "wd:id":"Q1474206",
         "wk:page":"Meherpur District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009700,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e034448de28cad3d95ebf2d1f1e83617",
+    "wof:geomhash":"97b18418b8056af5502fb0ba8046b3fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":421191661,
-    "wof:lastmodified":1690856113,
+    "wof:lastmodified":1695886591,
     "wof:name":"Meherpur",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/191/663/421191663.geojson
+++ b/data/421/191/663/421191663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307201,
-    "geom:area_square_m":3445516180.962352,
+    "geom:area_square_m":3445515438.979858,
     "geom:bbox":"88.395394,24.533596,89.167285,25.213333",
     "geom:latitude":24.898912,
     "geom:longitude":88.754003,
@@ -191,12 +191,13 @@
         "wd:id":"Q2094277",
         "wk:page":"Naogaon District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009700,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da0beadddbe951473df27cf815ea74b5",
+    "wof:geomhash":"a020d8664874619273c4740750c34864",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421191663,
-    "wof:lastmodified":1690856114,
+    "wof:lastmodified":1695886592,
     "wof:name":"Naogaon",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/191/745/421191745.geojson
+++ b/data/421/191/745/421191745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121937,
-    "geom:area_square_m":1379118438.830676,
+    "geom:area_square_m":1379118087.02896,
     "geom:bbox":"89.691972,23.629712,90.256906,24.030702",
     "geom:latitude":23.84059,
     "geom:longitude":89.954506,
@@ -180,12 +180,13 @@
         "qs_pg:id":1154551,
         "wd:id":"Q2024719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009704,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21ab88f9ebfcc82a2e5aa8a30a8171c0",
+    "wof:geomhash":"fad1767c8ab2fec4d8f5a6d2e60eb1ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421191745,
-    "wof:lastmodified":1690856114,
+    "wof:lastmodified":1695886592,
     "wof:name":"Manikganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/191/923/421191923.geojson
+++ b/data/421/191/923/421191923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.184781,
-    "geom:area_square_m":2071215529.371044,
+    "geom:area_square_m":2071216089.860888,
     "geom:bbox":"89.643176,24.564074,90.222294,25.432043",
     "geom:latitude":24.973281,
     "geom:longitude":89.852393,
@@ -219,12 +219,13 @@
         "qs_pg:id":1174951,
         "wd:id":"Q2039306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009714,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"51a5ce9158d27a5cd5ae7ceb91900918",
+    "wof:geomhash":"668f9d5f5b017a153c57c99a42445f99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":421191923,
-    "wof:lastmodified":1690856113,
+    "wof:lastmodified":1695886657,
     "wof:name":"Jamalpur",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/194/153/421194153.geojson
+++ b/data/421/194/153/421194153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101816,
-    "geom:area_square_m":1153605496.091947,
+    "geom:area_square_m":1153605529.586948,
     "geom:bbox":"88.641554,23.37165,89.019611,23.839585",
     "geom:latitude":23.608071,
     "geom:longitude":88.849911,
@@ -171,12 +171,13 @@
         "qs_pg:id":1026966,
         "wd:id":"Q2094570"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009795,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"155f730175379e1135a4cf2152f34290",
+    "wof:geomhash":"d122fa12fdddfe92bffcbedb28467850",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421194153,
-    "wof:lastmodified":1690856101,
+    "wof:lastmodified":1695886589,
     "wof:name":"Chuadanga",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/194/867/421194867.geojson
+++ b/data/421/194/867/421194867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136233,
-    "geom:area_square_m":1549514764.858847,
+    "geom:area_square_m":1549514848.467397,
     "geom:bbox":"89.672895,22.81794,90.130456,23.360558",
     "geom:latitude":23.096562,
     "geom:longitude":89.900043,
@@ -184,12 +184,13 @@
         "qs_pg:id":22371,
         "wd:id":"Q1537813"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009822,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d62439c9e0e65c021b9de7496c39d149",
+    "wof:geomhash":"016ee608b450dd93ce04adc0cfe65900",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":421194867,
-    "wof:lastmodified":1690856101,
+    "wof:lastmodified":1695886589,
     "wof:name":"Gopalganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/197/045/421197045.geojson
+++ b/data/421/197/045/421197045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069087,
-    "geom:area_square_m":781985488.851735,
+    "geom:area_square_m":781985977.949165,
     "geom:bbox":"90.431731,23.542405,90.757875,23.958316",
     "geom:latitude":23.740226,
     "geom:longitude":90.575194,
@@ -180,12 +180,13 @@
         "qs_pg:id":1289562,
         "wd:id":"Q2208354"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2498f52684be351f4a0353cdeec4405b",
+    "wof:geomhash":"67e2ce8d35b14bc19f93c5570666f15c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421197045,
-    "wof:lastmodified":1690856115,
+    "wof:lastmodified":1695886657,
     "wof:name":"Narayanganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/197/541/421197541.geojson
+++ b/data/421/197/541/421197541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214151,
-    "geom:area_square_m":2418022423.911048,
+    "geom:area_square_m":2418022662.992404,
     "geom:bbox":"89.000722,23.798061,89.739729,24.362362",
     "geom:latitude":24.05636,
     "geom:longitude":89.39325,
@@ -180,12 +180,13 @@
         "qs_pg:id":350672,
         "wd:id":"Q1083505"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009917,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78303d25a659d39758a5399f588a8804",
+    "wof:geomhash":"929f1e474da41a3f9dc58029186e433d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421197541,
-    "wof:lastmodified":1690856115,
+    "wof:lastmodified":1695886657,
     "wof:name":"Pabna",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/198/063/421198063.geojson
+++ b/data/421/198/063/421198063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18279,
-    "geom:area_square_m":2073139268.319088,
+    "geom:area_square_m":2073140334.081146,
     "geom:bbox":"89.489348,23.200925,90.187726,23.721302",
     "geom:latitude":23.476046,
     "geom:longitude":89.837466,
@@ -192,12 +192,13 @@
         "qs_pg:id":350673,
         "wd:id":"Q2093552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459009935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"047f0dc292c6e8d04ccd5e39336db74f",
+    "wof:geomhash":"dd825efc9c75ab5e69e559538b76141b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":421198063,
-    "wof:lastmodified":1690856112,
+    "wof:lastmodified":1695886592,
     "wof:name":"Faridpur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/200/811/421200811.geojson
+++ b/data/421/200/811/421200811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256221,
-    "geom:area_square_m":2874449526.974506,
+    "geom:area_square_m":2874450060.095457,
     "geom:bbox":"90.462421,24.567523,91.240831,25.196069",
     "geom:latitude":24.868135,
     "geom:longitude":90.843617,
@@ -182,12 +182,13 @@
         "wd:id":"Q2344966",
         "wk:page":"Netrokona District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010042,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95ed00af810b431e0e7bd49c8200bf41",
+    "wof:geomhash":"edb88bb36108a371c0806a83e5462404",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":421200811,
-    "wof:lastmodified":1690856116,
+    "wof:lastmodified":1695886592,
     "wof:name":"Netrakona",
     "wof:parent_id":1108803101,
     "wof:placetype":"county",

--- a/data/421/201/541/421201541.geojson
+++ b/data/421/201/541/421201541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358036,
-    "geom:area_square_m":4091286150.156923,
+    "geom:area_square_m":4091285118.074277,
     "geom:bbox":"91.422002,21.909291,92.186835,22.988774",
     "geom:latitude":22.46141,
     "geom:longitude":91.831395,
@@ -206,12 +206,13 @@
         "wd:id":"Q1074991",
         "wk:page":"Chittagong District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e04aa7b0aea99c31dcc99af3baf6c313",
+    "wof:geomhash":"e643499e40a23d26ada4e0af1b94592b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -221,7 +222,7 @@
         }
     ],
     "wof:id":421201541,
-    "wof:lastmodified":1690856118,
+    "wof:lastmodified":1695886657,
     "wof:name":"Chittagong",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/201/927/421201927.geojson
+++ b/data/421/201/927/421201927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302227,
-    "geom:area_square_m":3455578505.796061,
+    "geom:area_square_m":3455579373.174736,
     "geom:bbox":"88.898246,21.650822,89.363566,22.949218",
     "geom:latitude":22.379203,
     "geom:longitude":89.139833,
@@ -183,12 +183,13 @@
         "qs_pg:id":215992,
         "wd:id":"Q1233680"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010092,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee5347de3e2626bf9b95182740cec0cf",
+    "wof:geomhash":"f6acca7eee3313d773d58a2b782c358a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":421201927,
-    "wof:lastmodified":1690856118,
+    "wof:lastmodified":1695886593,
     "wof:name":"Satkhira",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/421/201/929/421201929.geojson
+++ b/data/421/201/929/421201929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.216629,
-    "geom:area_square_m":2439398887.014971,
+    "geom:area_square_m":2439399189.949841,
     "geom:bbox":"89.253643,24.01638,89.819781,24.785471",
     "geom:latitude":24.400163,
     "geom:longitude":89.599124,
@@ -193,12 +193,13 @@
         "qs_pg:id":215993,
         "wd:id":"Q2429432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010092,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"780bef1dcb853ace06394a1ec345341d",
+    "wof:geomhash":"0d7007b7a20eed5bc69f334a93a9f297",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":421201929,
-    "wof:lastmodified":1690856117,
+    "wof:lastmodified":1695886593,
     "wof:name":"Sirajganj",
     "wof:parent_id":85669031,
     "wof:placetype":"county",

--- a/data/421/201/931/421201931.geojson
+++ b/data/421/201/931/421201931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331353,
-    "geom:area_square_m":3715235648.473568,
+    "geom:area_square_m":3715235286.248152,
     "geom:bbox":"90.933235,24.566199,91.740052,25.205567",
     "geom:latitude":24.937672,
     "geom:longitude":91.347357,
@@ -174,12 +174,13 @@
         "qs_pg:id":215999,
         "wd:id":"Q2093388"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010092,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"995891339c351f4fa130e09a9ee59326",
+    "wof:geomhash":"683d98d0e99c1b26eb4a4d97880c82a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":421201931,
-    "wof:lastmodified":1690856117,
+    "wof:lastmodified":1695886593,
     "wof:name":"Sunamganj",
     "wof:parent_id":85669025,
     "wof:placetype":"county",

--- a/data/421/203/493/421203493.geojson
+++ b/data/421/203/493/421203493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149008,
-    "geom:area_square_m":1681761657.770659,
+    "geom:area_square_m":1681761219.189167,
     "geom:bbox":"90.151501,23.882544,90.700487,24.339309",
     "geom:latitude":24.111209,
     "geom:longitude":90.449892,
@@ -176,12 +176,13 @@
         "qs_pg:id":1289561,
         "wd:id":"Q2094101"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010154,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1f5fd6430f4760b1bae106f9a7dab5b",
+    "wof:geomhash":"4ac2505a87a877ab045afcbe8898731a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421203493,
-    "wof:lastmodified":1690856104,
+    "wof:lastmodified":1695886590,
     "wof:name":"Gazipur",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/205/057/421205057.geojson
+++ b/data/421/205/057/421205057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180024,
-    "geom:area_square_m":2071387642.869975,
+    "geom:area_square_m":2071387120.649869,
     "geom:bbox":"91.837178,20.576093,92.364826,21.951325",
     "geom:latitude":21.481,
     "geom:longitude":92.059699,
@@ -242,12 +242,13 @@
         "wd:id":"Q1122278",
         "wk:page":"Cox's Bazar"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010210,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4a20473a0938dad1d6ff9c9126ffb6f",
+    "wof:geomhash":"2fe0595d64924aecab9d91f663cfa04f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -257,7 +258,7 @@
         }
     ],
     "wof:id":421205057,
-    "wof:lastmodified":1690856105,
+    "wof:lastmodified":1695886590,
     "wof:name":"Cox's Bazar",
     "wof:parent_id":85669023,
     "wof:placetype":"county",

--- a/data/421/205/059/421205059.geojson
+++ b/data/421/205/059/421205059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082471,
-    "geom:area_square_m":934996052.777555,
+    "geom:area_square_m":934995706.960231,
     "geom:bbox":"90.180545,23.377595,90.712809,23.674192",
     "geom:latitude":23.527374,
     "geom:longitude":90.422476,
@@ -189,12 +189,13 @@
         "wd:id":"Q1990519",
         "wk:page":"Munshiganj District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010211,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf5d488208a1d4fcbd911a01904dee03",
+    "wof:geomhash":"7dddc9a7f9b6f2bac69601bf3138f80e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421205059,
-    "wof:lastmodified":1690856105,
+    "wof:lastmodified":1695886590,
     "wof:name":"Munshiganj",
     "wof:parent_id":85669009,
     "wof:placetype":"county",

--- a/data/421/205/213/421205213.geojson
+++ b/data/421/205/213/421205213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085095,
-    "geom:area_square_m":967662591.494867,
+    "geom:area_square_m":967663019.040614,
     "geom:bbox":"89.376997,22.95402,89.792497,23.31448",
     "geom:latitude":23.126122,
     "geom:longitude":89.575191,
@@ -184,12 +184,13 @@
         "wd:id":"Q1550260",
         "wk:page":"Narail District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1459010215,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77a1fba2f6bb5930db20f53f37aa010b",
+    "wof:geomhash":"5bc743dbe9d3531a10fe0bff7f7d2493",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":421205213,
-    "wof:lastmodified":1690856105,
+    "wof:lastmodified":1695886590,
     "wof:name":"Narail",
     "wof:parent_id":85669015,
     "wof:placetype":"county",

--- a/data/856/324/75/85632475.geojson
+++ b/data/856/324/75/85632475.geojson
@@ -1318,6 +1318,7 @@
         "hasc:id":"BD",
         "icao:code":"S2",
         "ioc:id":"BAN",
+        "iso:code":"BD",
         "itu:id":"BGD",
         "loc:id":"n81063207",
         "m49:code":"050",
@@ -1331,6 +1332,7 @@
         "wk:page":"Bangladesh",
         "wmo:id":"BW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:country_alpha3":"BGD",
     "wof:geom_alt":[
@@ -1353,7 +1355,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1694639578,
+    "wof:lastmodified":1695881238,
     "wof:name":"Bangladesh",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/690/09/85669009.geojson
+++ b/data/856/690/09/85669009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.818067,
-    "geom:area_square_m":20562773546.927612,
+    "geom:area_square_m":20562773717.36673,
     "geom:bbox":"89.298725,22.81794,91.255628,24.791218",
     "geom:latitude":23.835156,
     "geom:longitude":90.239762,
@@ -347,17 +347,19 @@
         "gn:id":1337179,
         "gp:id":2344791,
         "hasc:id":"BD.DH",
+        "iso:code":"BD-C",
         "iso:id":"BD-C",
         "qs_pg:id":913358,
         "unlc:id":"BD-13",
         "wd:id":"Q330158",
         "wk:page":"Dhaka Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"117120c63e0f40be9abc997ff9a22126",
+    "wof:geomhash":"a29801de9ec99b85d1d97b23bcfafb30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -372,7 +374,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856078,
+    "wof:lastmodified":1695884796,
     "wof:name":"Dhaka",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/15/85669015.geojson
+++ b/data/856/690/15/85669015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.826379,
-    "geom:area_square_m":20799844587.777939,
+    "geom:area_square_m":20799845544.927021,
     "geom:bbox":"88.559091,21.650822,89.983386,24.207734",
     "geom:latitude":22.916681,
     "geom:longitude":89.293656,
@@ -322,17 +322,19 @@
         "gn:id":1337210,
         "gp:id":2344792,
         "hasc:id":"BD.KH",
+        "iso:code":"BD-D",
         "iso:id":"BD-D",
         "qs_pg:id":890032,
         "unlc:id":"BD-27",
         "wd:id":"Q501696",
         "wk:page":"Khulna Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb18e5afbe5c3953f27b6ada15f7496c",
+    "wof:geomhash":"c17701106cc8bafb5e9271f8440491f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856079,
+    "wof:lastmodified":1695884796,
     "wof:name":"Khulna",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/19/85669019.geojson
+++ b/data/856/690/19/85669019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.869375,
-    "geom:area_square_m":9936952586.915474,
+    "geom:area_square_m":9936951130.720173,
     "geom:bbox":"89.855354,21.76194,91.040439,23.100407",
     "geom:latitude":22.424559,
     "geom:longitude":90.364962,
@@ -298,17 +298,19 @@
         "gn:id":1337229,
         "gp:id":23706410,
         "hasc:id":"BD.BA",
+        "iso:code":"BD-A",
         "iso:id":"BD-A",
         "qs_pg:id":212423,
         "unlc:id":"BD-06",
         "wd:id":"Q459723",
         "wk:page":"Barisal Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17cae34c15ba4526e4e8fd26f7387b25",
+    "wof:geomhash":"d4ee3629bde2b580f527712707fe8997",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856077,
+    "wof:lastmodified":1695884796,
     "wof:name":"Barisal",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/23/85669023.geojson
+++ b/data/856/690/23/85669023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.751161,
-    "geom:area_square_m":31378353511.345104,
+    "geom:area_square_m":31378352449.004955,
     "geom:bbox":"90.539196,20.576093,92.683448,24.26925",
     "geom:latitude":22.711939,
     "geom:longitude":91.729536,
@@ -318,17 +318,19 @@
         "gn:id":1337200,
         "gp:id":2344790,
         "hasc:id":"BD.CG",
+        "iso:code":"BD-B",
         "iso:id":"BD-B",
         "qs_pg:id":219507,
         "unlc:id":"BD-10",
         "wd:id":"Q158087",
         "wk:page":"Chittagong Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f34798f04fb1bd133b050aa4679b756e",
+    "wof:geomhash":"6cdb9b4241105abd219745ec724bab32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856078,
+    "wof:lastmodified":1695884797,
     "wof:name":"Chittagong",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/25/85669025.geojson
+++ b/data/856/690/25/85669025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.108546,
-    "geom:area_square_m":12451660090.936243,
+    "geom:area_square_m":12451659460.072384,
     "geom:bbox":"90.933235,23.974533,92.501155,25.205567",
     "geom:latitude":24.714484,
     "geom:longitude":91.666161,
@@ -293,17 +293,19 @@
         "gn:id":1477362,
         "gp:id":23706411,
         "hasc:id":"BD.SY",
+        "iso:code":"BD-G",
         "iso:id":"BD-G",
         "qs_pg:id":1192909,
         "unlc:id":"BD-60",
         "wd:id":"Q459732",
         "wk:page":"Sylhet Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9303e792cdf46880a0e9927927f87274",
+    "wof:geomhash":"5bab3fc423d3b8fe4f41416b2037ae8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856080,
+    "wof:lastmodified":1695884797,
     "wof:name":"Sylhet",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/31/85669031.geojson
+++ b/data/856/690/31/85669031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.621182,
-    "geom:area_square_m":18227684468.298546,
+    "geom:area_square_m":18227684366.216022,
     "geom:bbox":"88.01143,23.798061,89.819781,25.276321",
     "geom:latitude":24.591527,
     "geom:longitude":89.04558,
@@ -289,16 +289,18 @@
         "gn:id":1337166,
         "gp:id":2344793,
         "hasc:id":"BD.RS",
+        "iso:code":"BD-E",
         "iso:id":"BD-E",
         "qs_pg:id":318292,
         "wd:id":"Q379382",
         "wk:page":"Rajshahi Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b21024e729e9956db866213689d45ea4",
+    "wof:geomhash":"88d9d4b2e5b186ef3288ea2b818904b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856078,
+    "wof:lastmodified":1695884797,
     "wof:name":"Rajshahi",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/856/690/35/85669035.geojson
+++ b/data/856/690/35/85669035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.466399,
-    "geom:area_square_m":16327422804.298187,
+    "geom:area_square_m":16327422746.825804,
     "geom:bbox":"88.088999,25.035928,89.889671,26.634149",
     "geom:latitude":25.779542,
     "geom:longitude":89.057564,
@@ -188,15 +188,17 @@
         "gn:id":7671048,
         "gp:id":-2344793,
         "hasc:id":"BD.RP",
+        "iso:code":"BD-F",
         "iso:id":"BD-F",
         "unlc:id":"BD-55",
         "wd:id":"Q402021"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BD",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2cacfcada24527b08d98957558218aee",
+    "wof:geomhash":"b7afaa6f8fdd113e9abc6a426c237009",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -211,7 +213,7 @@
     "wof:lang_x_spoken":[
         "ben"
     ],
-    "wof:lastmodified":1690856076,
+    "wof:lastmodified":1695884795,
     "wof:name":"Rangpur",
     "wof:parent_id":85632475,
     "wof:placetype":"region",

--- a/data/890/438/075/890438075.geojson
+++ b/data/890/438/075/890438075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150271,
-    "geom:area_square_m":1698533954.740834,
+    "geom:area_square_m":1698533610.173521,
     "geom:bbox":"88.697571,23.690454,89.370359,24.207734",
     "geom:latitude":23.920633,
     "geom:longitude":89.035383,
@@ -179,12 +179,13 @@
         "wd:id":"Q956895",
         "wk:page":"Kushtia District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BD",
     "wof:created":1469052179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cdccadbe90384772e3f50035f01b06c7",
+    "wof:geomhash":"3a50b3edcd8afcd2a3a1de403d71207d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":890438075,
-    "wof:lastmodified":1690856125,
+    "wof:lastmodified":1695886594,
     "wof:name":"Kushtia",
     "wof:parent_id":85669015,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.